### PR TITLE
3 typos of "representd", in 4.1.1, 4.1.2, 4.3.2

### DIFF
--- a/index.html
+++ b/index.html
@@ -412,7 +412,7 @@ WebIDL.</p>
             <a>properties</a>, with the following value type assignments:</p>
             <ul>
               <li>Any number value MUST be represented as a Number type.</li>
-              <li>Any boolean value MUST be representd as a Boolean type.</li>
+              <li>Any boolean value MUST be represented as a Boolean type.</li>
               <li>Any sequence value MUST be represented as an Array type.</li>
               <li>Any unordered set of values MUST be represented as
               an Array type.</li>
@@ -442,7 +442,7 @@ WebIDL.</p>
             <a>properties</a>, with the following value type assignments:</p>
             <ul>
               <li>Any number value MUST be represented as a Number type.</li>
-              <li>Any boolean value MUST be representd as a Boolean type.</li>
+              <li>Any boolean value MUST be represented as a Boolean type.</li>
               <li>Any sequence value MUST be represented as an Array type.</li>
               <li>Any unordered set of values MUST be represented as
               an Array type.</li>
@@ -845,7 +845,7 @@ interface IdentityProfile {
               <li>Any number value MUST be represented as an
               appropriate valid numeric type, e.g. double or unsigned
               long.</li>
-              <li>Any boolean value MUST be representd as a boolean type.</li>
+              <li>Any boolean value MUST be represented as a boolean type.</li>
               <li>Any sequence value MUST be represented as a sequence
               type.</li>
               <li>Any unordered set of values MUST be represented as


### PR DESCRIPTION
Changed 3x to "represented" in "...MUST be representd as a Boolean type" in sections 4.1.1, 4.1.2, 4.3.2.
Fixes #22 

[Newbie aside: My branch is named 'typos-issues21-22', but discovered 21 must be changed in another file (it's in an inclusion), and so am doing it separately to avoid my head exploding.]