### PR TITLE
Adds description of Favoring Abstract Claims

### DIFF
--- a/index.html
+++ b/index.html
@@ -1230,8 +1230,14 @@ transmit verifiable claims on behalf of the Holder.
       <section>
         <h3>Favor Abstract Claims</h3>
 
-        <p class="issue">
-Favor “proof of” vs. “actual data”. Example: overAge: 21 vs. birthdate.
+        <p>
+In order to enable recipients of verifiable claims to use them in a variety of circumstances without revealing more personally identifiable information than necessary for the transaction, issuers should consider limiting the information published in a claim to a minimal set needed for the expected purposes.
+One way to avoid placing personally identifiable information in a claim is to use an "abstract" property that meets the needs of inspectors without providing specific information about the subject.
+        </p>
+        <p>
+An example used in this document is the use of the "ageOver" property as opposed to a specific birthdate that would be much stronger personally identifiable information.
+If retailers in a market commonly require purchasers to be older than a specific age, a trusted issuer may choose to offer a credential claiming that subjects have met that requirement as opposed to offering claims of their specific birthdates.
+This enables individual customers to purchase items without revealing specific personally identifiable information.
         </p>
       </section>
 

--- a/index.html
+++ b/index.html
@@ -1235,8 +1235,8 @@ In order to enable recipients of verifiable claims to use them in a variety of c
 One way to avoid placing personally identifiable information in a claim is to use an "abstract" property that meets the needs of inspectors without providing specific information about the subject.
         </p>
         <p>
-An example used in this document is the use of the "ageOver" property as opposed to a specific birthdate that would be much stronger personally identifiable information.
-If retailers in a market commonly require purchasers to be older than a specific age, a trusted issuer may choose to offer a credential claiming that subjects have met that requirement as opposed to offering claims of their specific birthdates.
+An example in this document is the use of the "ageOver" property as opposed to a specific birthdate that would constitute much stronger personally identifiable information.
+If retailers in a market commonly require purchasers to be older than a specific age, an issuer trusted in that market may choose to offer a credential claiming that subjects have met that requirement as opposed to offering claims of their specific birthdates.
 This enables individual customers to purchase items without revealing specific personally identifiable information.
         </p>
       </section>

--- a/index.html
+++ b/index.html
@@ -1235,7 +1235,7 @@ In order to enable recipients of verifiable claims to use them in a variety of c
 One way to avoid placing personally identifiable information in a claim is to use an "abstract" property that meets the needs of inspectors without providing specific information about the subject.
         </p>
         <p>
-An example in this document is the use of the "ageOver" property as opposed to a specific birthdate that would constitute much stronger personally identifiable information.
+An example in this document is the use of the <code>ageOver</code> property as opposed to a specific birthdate that would constitute much stronger personally identifiable information.
 If retailers in a market commonly require purchasers to be older than a specific age, an issuer trusted in that market may choose to offer a credential claiming that subjects have met that requirement as opposed to offering claims of their specific birthdates.
 This enables individual customers to purchase items without revealing specific personally identifiable information.
         </p>


### PR DESCRIPTION
Closes #6. 

Adds language defining "abstract claims" and explains an example `ageOver` used elsewhere in the text.