### PR TITLE
Add verification check instructions. Relates to #9.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1381,6 +1381,47 @@ Time periods should be shorter for highly dynamic information.
       </section>
     </section>
 
+    <section>
+      <h2>Verification</h2>
+
+      <p>
+This section describes a number of checks required to verify a claim.
+Some checks are essential for all verifiable claims, while some are applicable to only some claims.
+      </p>
+      <section>
+        <h3>Structural Validity</h3>
+        <p>
+          <ul>
+            <li>Document is valid JSON-LD.</li>
+            <li>Required properties are present. For example, for a Credential, <code>id</code>, <code>type</code>, and <code>claim</code> are required.</li>
+            <li>Property values match expectations described in the specification. For example, the document type for a verifiable claim must contain the class "Credential".</li>
+          </ul>
+        </p>
+      </section>
+      <section>
+        <h3>Entity Validity</h3>
+        <p>A number of checks </p>
+        <p>
+          <ul>
+            <li>The <code>issuer</code> id must match expectations. Likely, that means it is the id of a known and trusted <a>identity profile</a>.</li>
+            <li>The <a>claim id</a> must match expectations. Likely, that means it is the id of a known and trusted <a>identity profile</a> for the subject of the claim. If the entity that is subject of a claim has transmitted it to the inspector, the subject may be able to prove ownership of key identifyin properties such as email address(es) and public key(s).</li>
+            <li>The <code>issued</code> date must be in the expected range. For example, an inspector may wish to ensure that the recorded issued date of valid claims is not in the future.</li>
+            <li>The document signature is available in the form of a known signature suite.</li>
+            <li>The public key associated with the signature is available and a trustworthy link between this signing key and the issuer's <a>identify profile</a> may be established.</li>
+            <li>If revocation instructions are present, the claim must not have been revoked.</li>
+          </ul>
+        </p>
+      </section>
+      <section>
+        <h3>Fitness for Purpose</h3>
+        <p>
+          <ul>
+            <li>The <a>custom properties</a> in the <a>claim</a> are appropriate for the inspector's purpose. For example if an inspector needs to determine that a subject is older than 21 years of age, they may accept claims of specific birthdate or abstract properties such as <code>ageOver</code>.</li>
+            <li>The issuer is trusted by the inspector to make the claims at hand. For example, Fast Food Resturant A will not be trusted to make a claim that an individual may enjoy a lifetime 10% discount to its competitor Fast Food Restaurant B.</li>
+          </ul>
+        </p>
+      </section>
+    </section>
   </body>
 </html>
 

--- a/index.html
+++ b/index.html
@@ -1386,29 +1386,51 @@ Time periods should be shorter for highly dynamic information.
 
       <p>
 This section describes a number of checks required to verify a claim.
-Some checks are essential for all verifiable claims, while some are applicable to only some claims.
+Some checks are essential for all verifiable claims, while some are
+applicable to only some claims.
       </p>
       <section>
         <h3>Structural Validity</h3>
         <p>
           <ul>
             <li>Document is valid JSON-LD.</li>
-            <li>Required properties are present. For example, for a Credential, <code>id</code>, <code>type</code>, and <code>claim</code> are required.</li>
-            <li>Property values match expectations described in the specification. For example, the document type for a verifiable claim must contain the class "Credential".</li>
+            <li>Required properties are present. For example, for a
+            Credential, <code>type</code> and <code>claim</code> are
+            required.</li>
+            <li>Property values match expectations described in the
+            specification. For example, the document type for a verifiable
+            claim must contain the class "Credential".</li>
           </ul>
         </p>
       </section>
       <section>
         <h3>Entity Validity</h3>
-        <p>A number of checks </p>
+        <p>
+A number of checks must be implemented to ensure a set of entities related
+to a Credential have mutually compatible properties and are trustworthy.
+        </p>
         <p>
           <ul>
-            <li>The <code>issuer</code> id must match expectations. Likely, that means it is the id of a known and trusted <a>identity profile</a>.</li>
-            <li>The <a>claim id</a> must match expectations. Likely, that means it is the id of a known and trusted <a>identity profile</a> for the subject of the claim. If the entity that is subject of a claim has transmitted it to the inspector, the subject may be able to prove ownership of key identifyin properties such as email address(es) and public key(s).</li>
-            <li>The <code>issued</code> date must be in the expected range. For example, an inspector may wish to ensure that the recorded issued date of valid claims is not in the future.</li>
-            <li>The document signature is available in the form of a known signature suite.</li>
-            <li>The public key associated with the signature is available and a trustworthy link between this signing key and the issuer's <a>identify profile</a> may be established.</li>
-            <li>If revocation instructions are present, the claim must not have been revoked.</li>
+            <li>The <code>issuer</code> id must match expectations. Likely,
+            that means it is the id of a known and trusted <a>identity
+            profile</a>.</li>
+            <li>The claim subject identifier must match expectations.
+            Likely, that means it is the id of a known and trusted
+            <a>identity profile </a> for the subject of the claim. If the
+            entity that is subject of a claim has transmitted it to the
+            inspector, the subject may be able to prove ownership of key
+            identifying properties such as email address(es) and public
+            key(s).</li>
+            <li>The <code>issued</code> date must be in the expected range.
+            For example, an inspector may wish to ensure that the recorded
+            issued date of valid claims is not in the future.</li>
+            <li>The document signature is available in the form of a known
+            signature suite.</li>
+            <li>The public key associated with the signature is available
+            and a trustworthy link between this signing key and the
+            issuer's <a>identity profile</a> may be established.</li>
+            <li>If revocation instructions are present, the claim must not
+            have been revoked.</li>
           </ul>
         </p>
       </section>
@@ -1416,8 +1438,15 @@ Some checks are essential for all verifiable claims, while some are applicable t
         <h3>Fitness for Purpose</h3>
         <p>
           <ul>
-            <li>The <a>custom properties</a> in the <a>claim</a> are appropriate for the inspector's purpose. For example if an inspector needs to determine that a subject is older than 21 years of age, they may accept claims of specific birthdate or abstract properties such as <code>ageOver</code>.</li>
-            <li>The issuer is trusted by the inspector to make the claims at hand. For example, Fast Food Resturant A will not be trusted to make a claim that an individual may enjoy a lifetime 10% discount to its competitor Fast Food Restaurant B.</li>
+            <li>The <a>custom properties</a> in the <a>claim</a> should be
+            appropriate for the inspector's purpose. For example if an
+            inspector needs to determine that a subject is older than 21
+            years of age, they may accept claims of specific birthdate or
+            abstract properties such as <code>ageOver</code>.</li>
+            <li>The issuer is trusted by the inspector to make the claims
+            at hand. For example, Fast Food Resturant A will not be trusted
+            to make a claim that an individual may enjoy a lifetime 10%
+            discount to its competitor Fast Food Restaurant B.</li>
           </ul>
         </p>
       </section>


### PR DESCRIPTION
Adds some verification check instructions to page. Abstracts some text from the list I originally drafted in #9 about how profiles and keys are discovered to account for different possible ways these may be retrieved, accessed, and trusted.

@dlongley the data model for claim above does declare `id` is a required property, so I described it as such here as well. If the bearer token case you mentioned is to be taken into account, it'll require a change above as well.